### PR TITLE
Fixing bug: Unstable frame time

### DIFF
--- a/src/app-states/app.ts
+++ b/src/app-states/app.ts
@@ -26,6 +26,6 @@ export class App {
 
         setInterval(() => {
             this.topState().updateLogic(frameTime);
-        }, frameTime);
+        }, Math.floor(frameTime * 1000));
     }
 }


### PR DESCRIPTION
Simulation was being executed uncapped, but with fixed delta time value. Thus it ran at different speeds in different browsers and/or on different machines. Everything is slow as hell after this fix but we can tweak the values later.