### PR TITLE
Refactor AI with better FSM and FSM builder

### DIFF
--- a/src/ai/ai-brain.spec.ts
+++ b/src/ai/ai-brain.spec.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { EventQueue } from "../events/event-queue";
+import { KeyCode } from "../game/key-codes";
+import { Player } from "../game/player";
+import { AnimationEngine, AnimationFrame } from "../utility/animation";
+import { Vector } from "../utility/vector";
+import { AiBrain } from "./ai-brain";
+import { AiPoweredController } from "./ai-controller";
+
+const animations = {
+    idle: [new AnimationFrame(0, 0, 0, 0)],
+};
+
+describe("AiBrain", () => {
+    let controller: AiPoweredController;
+    let brain: AiBrain;
+    let player: Player;
+
+    // These must be the same as in gameSettings
+    const PLAYER_ROTATION_SPEED = 250;
+    const DT = 1 / 60;
+
+    beforeEach(() => {
+        controller = new AiPoweredController();
+        brain = new AiBrain(controller, 0);
+        player = new Player(
+            0,
+            controller,
+            new AnimationEngine(animations, 1),
+            new EventQueue(),
+        );
+
+        player.spawn({
+            position: Vector.zero(),
+            initialHealth: 1,
+            initialEnergy: 0,
+            maxEnergy: 1,
+        });
+    });
+
+    [0, 45, 90, 135, 180, 225, 260, 305, 359].forEach((startAngle) => {
+        [0, 45, 90, 135, 180, 225, 260, 305, 359].forEach((targetAngle) => {
+            it(`Can rotate from ${startAngle} to ${targetAngle}`, () => {
+                const anyPlayer = player as any;
+                const anyBrain = brain as any;
+                (anyPlayer.rotation as number) = startAngle;
+                (anyBrain.targetAngle as number) = targetAngle;
+
+                while (!anyBrain.isTargetAngleAchieved(player)) {
+                    //console.log("Player angle: " + player.getCoords().angle);
+                    controller.releaseKey(KeyCode.Left);
+                    controller.releaseKey(KeyCode.Right);
+
+                    anyBrain.rotateTowardsTarget(player);
+
+                    if (controller.isKeyPressed(KeyCode.Left)) {
+                        anyPlayer.updateRotation(-PLAYER_ROTATION_SPEED, DT);
+                    } else if (controller.isKeyPressed(KeyCode.Right)) {
+                        anyPlayer.updateRotation(PLAYER_ROTATION_SPEED, DT);
+                    } else {
+                        throw new Error("Not rotating");
+                    }
+                }
+            });
+        });
+    });
+});

--- a/src/ai/ai-brain.spec.ts
+++ b/src/ai/ai-brain.spec.ts
@@ -22,13 +22,16 @@ describe("AiBrain", () => {
 
     beforeEach(() => {
         controller = new AiPoweredController();
-        brain = new AiBrain(controller, 0);
         player = new Player(
             0,
             controller,
             new AnimationEngine(animations, 1),
             new EventQueue(),
         );
+        brain = new AiBrain(controller, player, {
+            MIN_SHOOT_DELAY: 1,
+            MAX_SHOOT_DELAY: 1,
+        });
 
         player.spawn({
             position: Vector.zero(),
@@ -46,12 +49,12 @@ describe("AiBrain", () => {
                 (anyPlayer.rotation as number) = startAngle;
                 (anyBrain.targetAngle as number) = targetAngle;
 
-                while (!anyBrain.isTargetAngleAchieved(player)) {
+                while (!anyBrain.isTargetAngleAchieved(brain)) {
                     //console.log("Player angle: " + player.getCoords().angle);
                     controller.releaseKey(KeyCode.Left);
                     controller.releaseKey(KeyCode.Right);
 
-                    anyBrain.rotateTowardsTarget(player);
+                    anyBrain.rotateTowardsTarget(brain);
 
                     if (controller.isKeyPressed(KeyCode.Left)) {
                         anyPlayer.updateRotation(-PLAYER_ROTATION_SPEED, DT);

--- a/src/ai/ai-brain.ts
+++ b/src/ai/ai-brain.ts
@@ -6,144 +6,134 @@ import { AiPoweredController } from "./ai-controller";
 import { getTimeBeforeCollision, sanitizeAngle } from "../utility/math";
 import { GameObject } from "../game/game-object";
 import { FastArray } from "../utility/fast-array";
+import { assert } from "chai";
+import { Fsm } from "./fsm";
+import { If, Do, DoNothing, not } from "./fsm-builder";
 
-enum AiState {
+export enum State {
     Start,
+    PickingTarget,
     TrackingAndShooting,
+    Hunting,
+    StartEvasion,
     Evading,
+    FinishEvasion,
     Drifting,
+}
+
+enum TargetingStrategy {
+    Closest,
+    Weakest,
 }
 
 export class AiBrain {
     private shootTimeout = 0;
-    private aiState = AiState.Start;
+    private goForwardTimeout = 0;
     private targetAngle = 0;
+    private fsm: Fsm;
+    private targetingStrategy: TargetingStrategy = TargetingStrategy.Closest;
+    private targetPlayer: Player;
 
     constructor(
         private controller: AiPoweredController,
-        private playerId: number,
-    ) {}
+        private myPlayer: Player,
+    ) {
+        const states = {
+            /* eslint-disable */
+            [State.Start]:
+                 Do(this.startStateFsmStateLogic)
+                .thenGoTo(State.PickingTarget),
+            [State.PickingTarget]:
+                Do(this.pickTargetPlayer).thenGoTo(State.TrackingAndShooting),
+                //Do(this.pickTargetPlayer).thenGoTo(State.Hunting),
+            [State.Hunting]:
+                 If(this.isCloseEnoughToTarget).goTo(State.TrackingAndShooting)
+                .otherwiseDo(this.trackAndGoForward),
+            [State.TrackingAndShooting]: 
+                 If(this.isCollisionImminent).goTo(State.StartEvasion)
+                .orIf(this.isEverybodyElseDead).goTo(State.Drifting)
+                //.orIf(not(this.isCloseEnoughToTarget)).goTo(State.PickingTarget)
+                .otherwiseDo(this.trackAndShoot),
+            [State.StartEvasion]:
+                 Do(this.pickEvasionAngle)
+                .thenGoTo(State.Evading),
+            [State.Evading]: 
+                 If(this.isTargetAngleAchieved).goTo(State.FinishEvasion)
+                .otherwiseDo(this.rotateTowardsTarget),
+            [State.FinishEvasion]:
+                 Do(this.randomlyGoForwardOrBackward)
+                .thenGoTo(State.TrackingAndShooting,
+            ),
+            [State.Drifting]: DoNothing(),
+            /* eslint-enable */
+        };
+        this.fsm = new Fsm(states, State.Start);
+        this.targetPlayer = this.myPlayer; // just to satisfy linter
+
+        if (this.myPlayer.id % 2 === 1) {
+            this.targetingStrategy = TargetingStrategy.Weakest;
+        }
+    }
 
     update(dt: number, context: GameContext) {
+        this.releaseInputs();
+        this.updateTimers(dt);
+        this.fsm.update(this, context);
+    }
+
+    reset() {
+        this.fsm.setState(State.Start);
+    }
+
+    /* NON FSM METHODS */
+    private releaseInputs() {
         this.controller.releaseKey(KeyCode.Up);
         this.controller.releaseKey(KeyCode.Down);
         this.controller.releaseKey(KeyCode.Left);
         this.controller.releaseKey(KeyCode.Right);
         this.controller.releaseKey(KeyCode.Shoot);
-
-        const myPlayer = this.getPlayerReference(context);
-        if (myPlayer === null) return; // player is dead, nothing to control
-
-        /**
-         * Note the structure of following FSM:
-         * Each state starts with series of test for
-         * transitions into different states.
-         *
-         * If a test succeeds, a bootstrap logic (state with default transition)
-         * is carried out and then the state is changed.
-         *
-         * If no transition should occur, default state
-         * logic is executed instead.
-         */
-        switch (this.aiState) {
-            case AiState.Start:
-                this.controller.pressKey(KeyCode.Up);
-                this.shootTimeout =
-                    Math.random() * context.settings.AI_MIN_SHOOT_DELAY +
-                    context.settings.AI_MIN_SHOOT_DELAY;
-                this.aiState = AiState.TrackingAndShooting;
-                break;
-
-            case AiState.TrackingAndShooting: {
-                if (this.isCollisionImminent(myPlayer, context)) {
-                    this.targetAngle = this.pickEvasionAngle(myPlayer);
-                    this.aiState = AiState.Evading;
-                    return;
-                }
-
-                const closestPlayer = this.pickClosestPlayer(myPlayer, context);
-                if (closestPlayer === null) {
-                    this.aiState = AiState.Drifting;
-                    return;
-                }
-
-                this.targetObject(myPlayer, closestPlayer);
-                this.rotateTowardsTarget(myPlayer);
-
-                this.shootTimeout -= dt;
-                if (this.shootTimeout <= 0) {
-                    this.controller.pressKey(KeyCode.Shoot);
-                    this.shootTimeout =
-                        Math.random() * context.settings.AI_MIN_SHOOT_DELAY +
-                        context.settings.AI_MIN_SHOOT_DELAY;
-                }
-                break;
-            }
-
-            case AiState.Evading: {
-                console.log(
-                    myPlayer.id +
-                        ": evading " +
-                        myPlayer.getCoords().angle +
-                        "->" +
-                        this.targetAngle,
-                );
-                if (this.isTargetAngleAchieved(myPlayer)) {
-                    console.log(myPlayer.id + ": evade angle achieved");
-                    this.controller.pressKey(
-                        (Math.random() * 10) % 2 == 0
-                            ? KeyCode.Up
-                            : KeyCode.Down,
-                    );
-                    this.aiState = AiState.TrackingAndShooting;
-                    return;
-                }
-
-                this.rotateTowardsTarget(myPlayer);
-                break;
-            }
-
-            default:
-            case AiState.Drifting:
-                // drifting, do nothing, you're last
-                // player alive
-                break;
-        }
+        this.controller.releaseKey(KeyCode.Boost);
     }
 
-    reset() {
-        this.aiState = AiState.Start;
+    private updateTimers(dt: number) {
+        if (this.shootTimeout > 0) this.shootTimeout -= dt;
+        if (this.goForwardTimeout > 0) this.goForwardTimeout -= dt;
     }
 
-    private getPlayerReference(context: GameContext): Player | null {
-        for (let i = 0; i < context.players.getSize(); i++)
-            if (context.players.getItem(i).id === this.playerId)
-                return context.players.getItem(i);
-        return null;
-    }
-
-    private pickClosestPlayer(
-        myPlayer: Player,
-        context: GameContext,
-    ): Player | null {
-        let closestPlayer: Player | null = null;
+    private getClosestPlayer(players: Player[]): Player {
+        let result: Player = players[0];
         let smallestDistance = Infinity;
 
-        for (const player of context.players) {
-            if (player.id == this.playerId) continue;
-
+        for (let i = 1; i < players.length; i++) {
             const distance = Vector.diff(
-                player.getCollider().getPosition(),
-                myPlayer.getCollider().getPosition(),
+                players[i].getCollider().getPosition(),
+                this.myPlayer.getCollider().getPosition(),
             ).getSize();
 
             if (distance < smallestDistance) {
-                closestPlayer = player;
+                result = players[i];
                 smallestDistance = distance;
             }
         }
 
-        return closestPlayer;
+        return result;
+    }
+
+    private getWeakestPlayer(players: Player[]): Player {
+        let result: Player = players[0];
+
+        for (let i = 1; i < players.length; i++) {
+            if (result.getHealth() > players[i].getHealth())
+                result = players[i];
+        }
+
+        return result;
+    }
+
+    private getOtherPlayers(players: FastArray<Player>): Player[] {
+        return players.filter((p) => {
+            return p.id != this.myPlayer.id;
+        });
     }
 
     private targetObject(myPlayer: Player, object: GameObject) {
@@ -179,39 +169,107 @@ export class AiBrain {
         return result;
     }
 
-    private isCollisionImminent(myPlayer: Player, context: GameContext) {
+    /* FSM CONDITIONS */
+    private isEverybodyElseDead(self: AiBrain, context: GameContext): boolean {
+        return context.players.getSize() <= 1;
+    }
+
+    private isCloseEnoughToTarget(self: AiBrain): boolean {
+        return (
+            Vector.diff(
+                self.myPlayer.getCoords().position,
+                self.targetPlayer.getCoords().position,
+            ).getSize() < 300
+        );
+    }
+
+    private isTargetAngleAchieved(self: AiBrain): boolean {
+        const myAngle = self.myPlayer.getCoords().angle;
+        const diffAngle = Math.abs(self.targetAngle - myAngle);
+        return diffAngle < 5;
+    }
+
+    private isCollisionImminent(self: AiBrain, context: GameContext) {
         const result =
-            this.isCollisionImminentForGivenFastArray(
-                myPlayer,
+            self.isCollisionImminentForGivenFastArray(
+                self.myPlayer,
                 context.obstacles,
             ) ||
-            this.isCollisionImminentForGivenFastArray(
-                myPlayer,
+            self.isCollisionImminentForGivenFastArray(
+                self.myPlayer,
                 context.projectiles,
             );
 
-        // TODO: want to test players once we enable collisions between them
+        // TODO: want to FsmCondition players once we enable collisions between them
 
-        if (result) console.log(myPlayer.id + ": Collision imminent");
+        if (result) console.log(self.myPlayer.id + ": Collision imminent");
         return result;
     }
 
-    private pickEvasionAngle(myPlayer: Player): number {
-        return sanitizeAngle(myPlayer.getForward().toAngle() + 90);
+    /* FSM LOGIC */
+    private startStateFsmStateLogic(self: AiBrain, context: GameContext) {
+        console.log(self);
+        self.randomlyGoForwardOrBackward(self);
+        self.shootTimeout =
+            Math.random() * context.settings.AI_MIN_SHOOT_DELAY +
+            context.settings.AI_MIN_SHOOT_DELAY;
     }
 
-    private isTargetAngleAchieved(myPlayer: Player): boolean {
-        const myAngle = myPlayer.getCoords().angle;
-        const diffAngle = Math.abs(this.targetAngle - myAngle);
-        // There's some weird issue with rotateTowardsAngle, so it always
-        // becomes stuck in opposite direction
-        return diffAngle < 5; // || diffAngle - 180 < 5;
+    private randomlyGoForwardOrBackward(self: AiBrain) {
+        self.controller.pressKey(
+            (Math.random() * 10) % 2 == 0 ? KeyCode.Up : KeyCode.Down,
+        );
     }
 
-    private rotateTowardsTarget(myPlayer: Player) {
-        const myAngle = myPlayer.getCoords().angle;
-        const diffAngle = sanitizeAngle(myAngle - this.targetAngle);
-        if (diffAngle <= 180) this.controller.pressKey(KeyCode.Left);
-        else if (diffAngle > 180) this.controller.pressKey(KeyCode.Right);
+    private trackAndShoot(self: AiBrain, context: GameContext) {
+        self.targetObject(self.myPlayer, self.targetPlayer);
+        self.rotateTowardsTarget(self);
+
+        if (self.shootTimeout <= 0) {
+            self.controller.pressKey(KeyCode.Shoot);
+            self.shootTimeout =
+                Math.random() * context.settings.AI_MIN_SHOOT_DELAY +
+                context.settings.AI_MIN_SHOOT_DELAY;
+        }
+    }
+
+    private trackAndGoForward(self: AiBrain) {
+        self.targetObject(self.myPlayer, self.targetPlayer);
+        self.rotateTowardsTarget(self);
+
+        if (self.goForwardTimeout <= 0) {
+            self.controller.pressKey(KeyCode.Up);
+            self.goForwardTimeout = 0.4;
+        }
+    }
+
+    private pickTargetPlayer(self: AiBrain, context: GameContext) {
+        const otherPlayers = self.getOtherPlayers(context.players);
+        assert(
+            otherPlayers.length,
+            "Programmatic error: This function should never be called if there are no other players",
+        );
+
+        switch (self.targetingStrategy) {
+            case TargetingStrategy.Closest:
+                self.targetPlayer = self.getClosestPlayer(otherPlayers);
+                break;
+            case TargetingStrategy.Weakest:
+                self.targetPlayer = self.getWeakestPlayer(otherPlayers);
+                break;
+        }
+    }
+
+    private pickEvasionAngle(self: AiBrain) {
+        self.targetAngle = sanitizeAngle(
+            self.myPlayer.getForward().toAngle() + 90,
+        );
+    }
+
+    private rotateTowardsTarget(self: AiBrain) {
+        const myAngle = self.myPlayer.getCoords().angle;
+        const diffAngle = sanitizeAngle(myAngle - self.targetAngle);
+        if (diffAngle <= 180) self.controller.pressKey(KeyCode.Left);
+        else if (diffAngle > 180) self.controller.pressKey(KeyCode.Right);
     }
 }

--- a/src/ai/fsm-builder.ts
+++ b/src/ai/fsm-builder.ts
@@ -1,12 +1,12 @@
-import { AiBrain, State } from "./ai-brain";
-import {
-    FsmTransitionCondition,
-    FsmStateLogic,
-    FsmState,
-    FsmTransition,
-} from "./fsm";
-import { GameContext } from "../game/game-context";
 import { assert } from "chai";
+import { GameContext } from "../game/game-context";
+import { State } from "./ai-brain";
+import {
+    FsmState,
+    FsmStateLogic,
+    FsmTransition,
+    FsmTransitionCondition,
+} from "./fsm";
 
 export function DoNothing(): FsmState {
     return [];

--- a/src/ai/fsm-builder.ts
+++ b/src/ai/fsm-builder.ts
@@ -27,8 +27,8 @@ class FsmTransitionBuilder {
     ) {}
 
     goTo(state: State): FsmConditionBuilder {
-        this.transitions.push((self: AiBrain, context: GameContext) => {
-            return this.currentCondition(self, context) ? state : null;
+        this.transitions.push((context: GameContext) => {
+            return this.currentCondition(context) ? state : null;
         });
         return new FsmConditionBuilder(this.transitions);
     }
@@ -53,8 +53,8 @@ class FsmDefaultLogicBuilder {
     ) {}
 
     thenGoTo(state: State): FsmState {
-        this.transitions.push((self: AiBrain, context: GameContext) => {
-            this.defaultLogic(self, context);
+        this.transitions.push((context: GameContext) => {
+            this.defaultLogic(context);
             return state;
         });
         return this.transitions;
@@ -65,8 +65,8 @@ class FsmDefaultLogicBuilder {
             this.transitions.length !== 0,
             "You are trying to make a FSM state is looping and has no transition conditions",
         );
-        this.transitions.push((self: AiBrain, context: GameContext) => {
-            this.defaultLogic(self, context);
+        this.transitions.push((context: GameContext) => {
+            this.defaultLogic(context);
             return null;
         });
         return this.transitions;

--- a/src/ai/fsm-builder.ts
+++ b/src/ai/fsm-builder.ts
@@ -1,0 +1,67 @@
+import { AiBrain, State } from "./ai-brain";
+import { FsmState, FsmTransition } from "./fsm";
+import { GameContext } from "../game/game-context";
+
+type FsmCondition = (self: AiBrain, context: GameContext) => boolean;
+type FsmStateLogic = (self: AiBrain, context: GameContext) => void;
+
+export function DoNothing(): FsmState {
+    return [];
+}
+
+export function If(condition: FsmCondition): FsmConditionBuilder {
+    return new FsmConditionBuilder(condition, []);
+}
+
+export function Do(logic: FsmStateLogic): FsmHopStateBuilder {
+    return new FsmHopStateBuilder(logic);
+}
+
+export function not(condition: FsmCondition): FsmCondition {
+    return (self: AiBrain, context: GameContext) => {
+        return !condition(self, context);
+    };
+}
+
+class FsmHopStateBuilder {
+    constructor(private logic: FsmStateLogic) {}
+
+    thenGoTo(state: State): FsmState {
+        return [
+            (self: AiBrain, context: GameContext) => {
+                this.logic(self, context);
+                return state;
+            },
+        ];
+    }
+}
+
+class FsmLoopingStateBuilder {
+    constructor(private transitions: FsmTransition[]) {}
+
+    orIf(condition: FsmCondition): FsmConditionBuilder {
+        return new FsmConditionBuilder(condition, this.transitions);
+    }
+
+    otherwiseDo(logic: FsmStateLogic): FsmState {
+        this.transitions.push((self: AiBrain, context: GameContext) => {
+            logic(self, context);
+            return null;
+        });
+        return this.transitions;
+    }
+}
+
+class FsmConditionBuilder {
+    constructor(
+        public nextCondition: FsmCondition,
+        private transitions: FsmTransition[],
+    ) {}
+
+    goTo(nextState: State): FsmLoopingStateBuilder {
+        this.transitions.push((self: AiBrain, context: GameContext) => {
+            return this.nextCondition(self, context) ? nextState : null;
+        });
+        return new FsmLoopingStateBuilder(this.transitions);
+    }
+}

--- a/src/ai/fsm.ts
+++ b/src/ai/fsm.ts
@@ -1,15 +1,9 @@
-import { AiBrain, State } from "./ai-brain";
+import { State } from "./ai-brain";
 import { GameContext } from "../game/game-context";
 
-export type FsmTransitionCondition = (
-    self: AiBrain,
-    context: GameContext,
-) => boolean;
-export type FsmStateLogic = (self: AiBrain, context: GameContext) => void;
-export type FsmTransition = (
-    self: AiBrain,
-    context: GameContext,
-) => State | null;
+export type FsmTransitionCondition = (context: GameContext) => boolean;
+export type FsmStateLogic = (context: GameContext) => void;
+export type FsmTransition = (context: GameContext) => State | null;
 
 // FsmState consist of:
 // * array of pairs - FsmCondition and code of state to go to if condition is true
@@ -33,12 +27,12 @@ export class Fsm {
         this.currentState = initialState;
     }
 
-    update(self: AiBrain, context: GameContext) {
+    update(context: GameContext) {
         const state = this.states[this.currentState];
         if (state === undefined) return;
 
         for (const transition of state) {
-            const newState = transition(self, context);
+            const newState = transition(context);
             if (newState !== null) {
                 this.currentState = newState;
                 return;

--- a/src/ai/fsm.ts
+++ b/src/ai/fsm.ts
@@ -1,12 +1,26 @@
 import { AiBrain, State } from "./ai-brain";
 import { GameContext } from "../game/game-context";
 
+export type FsmTransitionCondition = (
+    self: AiBrain,
+    context: GameContext,
+) => boolean;
+export type FsmStateLogic = (self: AiBrain, context: GameContext) => void;
 export type FsmTransition = (
     self: AiBrain,
     context: GameContext,
 ) => State | null;
-// FsmState is an array of logic chunks that either return new state to transition into
-// or returns void so the next logic chunk is executed instead
+
+// FsmState consist of:
+// * array of pairs - FsmCondition and code of state to go to if condition is true
+// * default behaviour
+// * default state to go to (or null if state is supposed to loop)
+// However we can simplify it as array of transitions, where
+// each transitions does some logic and returns either new state code
+// or null.
+// This allows far greater expressiveness than we need and supports
+// simpler evaluation code.
+// fsm builder module is here to help the user set up the structures properly.
 export type FsmState = FsmTransition[];
 
 export class Fsm {
@@ -34,5 +48,9 @@ export class Fsm {
 
     setState(state: State) {
         this.currentState = state;
+    }
+
+    getState(): State {
+        return this.currentState;
     }
 }

--- a/src/ai/fsm.ts
+++ b/src/ai/fsm.ts
@@ -1,0 +1,38 @@
+import { AiBrain, State } from "./ai-brain";
+import { GameContext } from "../game/game-context";
+
+export type FsmTransition = (
+    self: AiBrain,
+    context: GameContext,
+) => State | null;
+// FsmState is an array of logic chunks that either return new state to transition into
+// or returns void so the next logic chunk is executed instead
+export type FsmState = FsmTransition[];
+
+export class Fsm {
+    private currentState: State;
+
+    constructor(
+        private states: Partial<Record<State, FsmState>>,
+        initialState: State,
+    ) {
+        this.currentState = initialState;
+    }
+
+    update(self: AiBrain, context: GameContext) {
+        const state = this.states[this.currentState];
+        if (state === undefined) return;
+
+        for (const transition of state) {
+            const newState = transition(self, context);
+            if (newState !== null) {
+                this.currentState = newState;
+                return;
+            }
+        }
+    }
+
+    setState(state: State) {
+        this.currentState = state;
+    }
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -42,7 +42,6 @@ export class App {
         for (let i = HUMAN_PLAYER_COUNT; i < this.settings.PLAYER_COUNT; i++) {
             const aiController = new AiPoweredController();
             this.controllers.push(aiController);
-            this.aiBrains.push(new AiBrain(aiController, i));
         }
 
         const createAnimationEngine = (
@@ -90,6 +89,15 @@ export class App {
                 console.log("Debug: " + msg);
             },
         };
+
+        for (let i = HUMAN_PLAYER_COUNT; i < this.settings.PLAYER_COUNT; i++) {
+            this.aiBrains.push(
+                new AiBrain(
+                    this.controllers[i] as AiPoweredController,
+                    this.gameContext.players.getItem(i),
+                ),
+            );
+        }
 
         this.reset();
     }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -47,9 +47,7 @@ export class App {
             this.controllers.push(aiController);
         }
 
-        const createAnimationEngine = (
-            animationSetName: string,
-        ): AnimationEngine => {
+        const createAnimationEngine = (animationSetName: string) => {
             return new AnimationEngine(
                 this.animationDB[animationSetName],
                 this.settings.ANIMATION_FPS,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -95,6 +95,10 @@ export class App {
                 new AiBrain(
                     this.controllers[i] as AiPoweredController,
                     this.gameContext.players.getItem(i),
+                    {
+                        MIN_SHOOT_DELAY: this.settings.AI_MIN_SHOOT_DELAY,
+                        MAX_SHOOT_DELAY: this.settings.AI_MAX_SHOOT_DELAY,
+                    },
                 ),
             );
         }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -161,6 +161,10 @@ export class App {
             alert("Programmatic error: Event queue not empty");
         }
 
+        this.aiBrains.forEach((brain) => {
+            brain.reset();
+        });
+
         this.spawnPlayersAndRocks();
     }
 

--- a/src/game/game-object.ts
+++ b/src/game/game-object.ts
@@ -4,7 +4,7 @@ import { GameContext } from "./game-context";
 import { Coords } from "../utility/coords";
 
 export abstract class GameObject {
-    protected hash = crypto.randomUUID();
+    protected hash = "";
     // dummy values, must be overriden in derived ctor
     protected collider: CircleCollider = new CircleCollider(Vector.zero(), 0);
     protected forward: Vector = Vector.zero();

--- a/src/game/game-settings.ts
+++ b/src/game/game-settings.ts
@@ -13,6 +13,9 @@ export interface GameSettings {
     PLAYER_INITIAL_HEALTH: number;
     PLAYER_INITIAL_ENERGY: number;
     PLAYER_MAX_ENERGY: number;
+    // AI Settings
+    AI_MAX_SHOOT_DELAY: number;
+    AI_MIN_SHOOT_DELAY: number;
     // Simulation settings
     //   Player
     PLAYER_FORWARD_SPEED: number;

--- a/src/game/player.ts
+++ b/src/game/player.ts
@@ -25,7 +25,8 @@ export class Player extends GameObject {
     constructor(
         readonly id: number,
         private controller: Controller,
-        private animationEngine: AnimationEngine,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        private animationEngine: AnimationEngine<any>,
         private eventQueue: EventQueue,
     ) {
         super();

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,12 +68,15 @@ const gameSettings = {
     PLAYER_NAMES: ["red", "green", "blue", "yellow"],
     DISPLAY_PLAYER_NAMES: true,
     // Spawn settings
-    PLAYER_COUNT: 2,
-    NPC_COUNT: 0,
+    PLAYER_COUNT: 4,
+    NPC_COUNT: 4,
     ROCK_COUNT: 4,
     PLAYER_INITIAL_HEALTH: 3,
     PLAYER_INITIAL_ENERGY: 2,
     PLAYER_MAX_ENERGY: 4,
+    // AI Settings
+    AI_MAX_SHOOT_DELAY: 2,
+    AI_MIN_SHOOT_DELAY: 0.5,
     // Simulation settings
     //   Player
     PLAYER_FORWARD_SPEED: 500,
@@ -111,3 +114,4 @@ appView.scale();
 window.onresize = debounce(() => {
     appView.scale();
 }, 200);
+(window as any).app = app;

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ const gameSettings = {
     PLAYER_INITIAL_ENERGY: 2,
     PLAYER_MAX_ENERGY: 4,
     // AI Settings
-    AI_MAX_SHOOT_DELAY: 2,
+    AI_MAX_SHOOT_DELAY: 1.5,
     AI_MIN_SHOOT_DELAY: 0.5,
     // Simulation settings
     //   Player

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,4 +115,6 @@ appView.scale();
 window.onresize = debounce(() => {
     appView.scale();
 }, 200);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).app = app;

--- a/src/utility/animation.ts
+++ b/src/utility/animation.ts
@@ -7,14 +7,14 @@ export class AnimationFrame {
     ) {}
 }
 
-export class AnimationEngine {
+export class AnimationEngine<TStates extends Record<string, AnimationFrame[]>> {
     private loop = false;
     private frameIndex = 0;
     private frameTimer = 0;
     private frameTimeout = 0;
-    private currentState = "";
+    private currentState: keyof TStates = "";
 
-    constructor(private states: Record<string, AnimationFrame[]>, fps: number) {
+    constructor(private states: TStates, fps: number) {
         this.frameTimeout = 1 / fps;
     }
 
@@ -38,7 +38,7 @@ export class AnimationEngine {
         return true;
     }
 
-    setState(name: string, looping = false) {
+    setState(name: keyof TStates, looping = false) {
         if (this.states[name] === undefined)
             throw (
                 "Programatic error: Trying to use non-existent animation state " +
@@ -56,7 +56,7 @@ export class AnimationEngine {
     }
 
     getCurrentFrame(): AnimationFrame {
-        const state = this.states[this.currentState]!;
+        const state = this.states[this.currentState];
         return state[this.frameIndex];
     }
 }

--- a/src/utility/animation.ts
+++ b/src/utility/animation.ts
@@ -7,7 +7,13 @@ export class AnimationFrame {
     ) {}
 }
 
-export class AnimationEngine<TStates extends Record<string, AnimationFrame[]>> {
+export class AnimationEngine<
+    // TODO: figure out how to couple concrete animation engine to concrete game objects
+    TStates extends Record<string, AnimationFrame[]> = Record<
+        string,
+        AnimationFrame[]
+    >,
+> {
     private loop = false;
     private frameIndex = 0;
     private frameTimer = 0;

--- a/src/utility/fast-array.ts
+++ b/src/utility/fast-array.ts
@@ -83,4 +83,12 @@ export class FastArray<T> implements Iterable<T> {
     forEach(cb: (item: T, index: number) => void) {
         for (let i = 0; i < this.size; i++) cb(this.items[i], i);
     }
+
+    filter(condition: (a: T) => boolean): T[] {
+        const result: T[] = [];
+        this.forEach((item: T) => {
+            if (condition(item)) result.push(item);
+        });
+        return result;
+    }
 }

--- a/src/utility/fast-array.ts
+++ b/src/utility/fast-array.ts
@@ -70,7 +70,7 @@ export class FastArray<T> implements Iterable<T> {
     }
 
     // Implementing Iterable<T>
-    [Symbol.iterator](): Iterator<T, any, undefined> {
+    [Symbol.iterator](): Iterator<T, T, undefined> {
         let index = 0;
         return {
             next: () => ({

--- a/src/utility/math.spec.ts
+++ b/src/utility/math.spec.ts
@@ -128,4 +128,11 @@ describe("GameMath", () => {
             expect(GameMath.sanitizeAngle(721)).to.equal(1);
         });
     });
+
+    it("Properly computes radial difference", () => {
+        expect(GameMath.radialDifference(0, 10)).to.equal(10);
+        expect(GameMath.radialDifference(0, 350)).to.equal(10);
+        expect(GameMath.radialDifference(350, 0)).to.equal(10);
+        expect(GameMath.radialDifference(0, 180)).to.equal(180);
+    });
 });

--- a/src/utility/math.spec.ts
+++ b/src/utility/math.spec.ts
@@ -135,4 +135,104 @@ describe("GameMath", () => {
         expect(GameMath.radialDifference(350, 0)).to.equal(10);
         expect(GameMath.radialDifference(0, 180)).to.equal(180);
     });
+
+    describe("getIntersectionBetweenMovingPointAndGrowingCircle", () => {
+        it("returns null, if point is moving away from circle and has higher speed than is circle grow rate", () => {
+            const pointOrigin = Vector.zero();
+            const pointForward = new Vector(-10, 0);
+            const circleOrigin = new Vector(1, 0);
+            const circleGrowSpeed = 9;
+
+            expect(
+                GameMath.getIntersectionBetweenMovingPointAndGrowingCircle(
+                    pointOrigin,
+                    pointForward,
+                    circleOrigin,
+                    circleGrowSpeed,
+                ),
+            ).to.be.null;
+        });
+
+        it("returns null if point is moving perpendicular to the circle at higher speed", () => {
+            const pointOrigin = Vector.zero();
+            const pointForward = new Vector(0, 10);
+            const circleOrigin = new Vector(1, 0);
+            const circleGrowSpeed = 5;
+
+            expect(
+                GameMath.getIntersectionBetweenMovingPointAndGrowingCircle(
+                    pointOrigin,
+                    pointForward,
+                    circleOrigin,
+                    circleGrowSpeed,
+                ),
+            ).to.be.null;
+        });
+
+        it("returns vector, if point is moving away from circle but at lower speed than circle grow rate", () => {
+            const pointOrigin = Vector.zero();
+            const pointForward = new Vector(-5, 0);
+            const circleOrigin = new Vector(1, 0);
+            const circleGrowSpeed = 6;
+
+            const result =
+                GameMath.getIntersectionBetweenMovingPointAndGrowingCircle(
+                    pointOrigin,
+                    pointForward,
+                    circleOrigin,
+                    circleGrowSpeed,
+                );
+
+            expect(result).not.be.null;
+
+            if (result !== null) {
+                expect(result.x).to.equal(-5);
+                expect(result.y).to.equal(0);
+            }
+        });
+
+        it("returns vector if point is moving perpendicular to the circle but at lower speed", () => {
+            const pointOrigin = Vector.zero();
+            const pointForward = new Vector(0, 1);
+            const circleOrigin = new Vector(1, 0);
+            const circleGrowSpeed = 2;
+
+            const result =
+                GameMath.getIntersectionBetweenMovingPointAndGrowingCircle(
+                    pointOrigin,
+                    pointForward,
+                    circleOrigin,
+                    circleGrowSpeed,
+                );
+
+            expect(result).not.be.null;
+
+            if (result !== null) {
+                expect(result.x).to.equal(0);
+                expect(result.y).to.be.approximately(0.577, 0.001);
+            }
+        });
+
+        it("returns vector under normal circumstances", () => {
+            const pointOrigin = new Vector(1, 4);
+            const pointForward = new Vector(2, 1);
+            const circleOrigin = new Vector(3, 1);
+            const circleGrowSpeed = 3;
+
+            const result =
+                GameMath.getIntersectionBetweenMovingPointAndGrowingCircle(
+                    pointOrigin,
+                    pointForward,
+                    circleOrigin,
+                    circleGrowSpeed,
+                );
+
+            expect(result).not.be.null;
+
+            if (result !== null) {
+                expect(result.x).to.be.approximately(4.14, 0.0001);
+                expect(result.y).to.be.approximately(5.57, 0.0001);
+            }
+        });
+    });
 });

--- a/src/utility/math.ts
+++ b/src/utility/math.ts
@@ -1,3 +1,4 @@
+import { assert } from "chai";
 import { CircleCollider } from "./circle-collider";
 import { Vector } from "./vector";
 
@@ -89,3 +90,39 @@ export function radialDifference(alfa: number, beta: number): number {
     );
 }
 
+/**
+ * This method basically computes "where should I aim to hit a target moving at given speed when
+ * projectiles have that speed".
+ * @param pointOrigin Where target currently sits at
+ * @param pointForward Target forward vector
+ * @param circleOrigin Player position
+ * @param circleGrowSpeed Speed of the projectile
+ * @returns Vector if such point exists (from the game standpoint that should be always) or null
+ * if there is none.
+ */
+export function getIntersectionBetweenMovingPointAndGrowingCircle(
+    pointOrigin: Vector,
+    pointForward: Vector,
+    circleOrigin: Vector,
+    circleGrowSpeed: number,
+): Vector | null {
+    const X = pointOrigin.x - circleOrigin.x;
+    const Y = pointOrigin.y - circleOrigin.y;
+    const A =
+        pointForward.x * pointForward.x +
+        pointForward.y * pointForward.y -
+        circleGrowSpeed * circleGrowSpeed;
+    const B = 2 * (X * pointForward.x + Y * pointForward.y);
+    const C = X * X + Y * Y;
+    const D = B * B - 4 * A * C;
+
+    // If point is moving perpendicular to circle and at a higher speed
+    if (D < 0) return null;
+
+    const t = (-B - Math.sqrt(D)) / (2 * A);
+
+    // If point is moving from circle at a higher speed
+    if (t < 0) return null;
+
+    return pointOrigin.getSum(pointForward.getScaled(t));
+}

--- a/src/utility/math.ts
+++ b/src/utility/math.ts
@@ -81,3 +81,11 @@ export function sanitizeAngle(angle: number): number {
     const rem = angle % 360;
     return rem < 0 ? rem + 360 : rem;
 }
+
+export function radialDifference(alfa: number, beta: number): number {
+    return Math.min(
+        Math.abs(alfa - beta),
+        Math.min(alfa, beta) + 360 - Math.max(alfa, beta),
+    );
+}
+

--- a/src/utility/timer.ts
+++ b/src/utility/timer.ts
@@ -1,0 +1,19 @@
+export class Timer {
+    private value: number;
+
+    constructor(private getInitValue: () => number) {
+        this.value = this.getInitValue();
+    }
+
+    update(dt: number) {
+        if (!this.ended()) this.value -= dt;
+    }
+
+    reset() {
+        this.value = this.getInitValue();
+    }
+
+    ended(): boolean {
+        return this.value <= 0;
+    }
+}

--- a/src/utility/vector.spec.ts
+++ b/src/utility/vector.spec.ts
@@ -87,4 +87,14 @@ describe("Vector", () => {
             expect(v1.getSize()).to.be.approximately(10, 0.001);
         });
     });
+
+    [new Vector(-266, 583), new Vector(1, 1), new Vector(0, -10)].forEach(
+        (v) => {
+            it(`Correctly constructs from polar coordinates |${v.toString()}| = ${v.getSize()}, alfa = ${v.toAngle()}`, () => {
+                const v2 = Vector.fromPolar(v.toAngle(), v.getSize());
+                expect(v2.x).to.be.approximately(v.x, 0.001);
+                expect(v2.y).to.be.approximately(v.y, 0.001);
+            });
+        },
+    );
 });

--- a/src/utility/vector.ts
+++ b/src/utility/vector.ts
@@ -30,6 +30,11 @@ export class Vector {
         return new Vector(-100, -100);
     }
 
+    static fromPolar(angle: number, size: number) {
+        const rad = (angle * Math.PI) / 180;
+        return new Vector(Math.cos(rad) * size, Math.sin(rad) * size);
+    }
+
     copy(): Vector {
         return new Vector(this.x, this.y);
     }

--- a/src/view-canvas/app-view.ts
+++ b/src/view-canvas/app-view.ts
@@ -3,7 +3,7 @@ import { App } from "../app/app";
 import { Vector } from "../utility/vector";
 import { AnimationFrame } from "../utility/animation";
 import { Player } from "../game/player";
-import spriteheetUrl from '../assets/spritesheet_v2.png';
+import spriteheetUrl from "../assets/spritesheet_v2.png";
 
 export class Sprite {
     constructor(private texture: CanvasImageSource) {}
@@ -71,6 +71,7 @@ export class AppViewCanvas {
         private canvas2d: HTMLCanvasElement,
         private hudFrames: Record<string, AnimationFrame>,
     ) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.context2d = this.canvas2d.getContext("2d")!;
 
         this.texture = new Image();


### PR DESCRIPTION
This PR separates AI Final State Machine into its own class (alongside with Timers) and adds a builder to create new FSM states. Because I don't know how to make it templated, the FSM is tightly coupled to the list of states defined in AiBrain.

**How the FSM works?**

At the top level, each state of the FSM has a list of conditions, that are always evaluated in order. If any of these conditions returns true, FSM transitions to state associated with the condition.

After evaluating conditions, if all of them were false, the FSM executes the default behaviour of the state and if there is a default transition, it jumps to the next state.

**How the builder works**

If you import If, Do and DoNothing symbols from fsm-builder module, you can easily build new states:

```
 If(someCondition).goTo(stateCode)
.orIf(anotherCondition).goTo(anotherState)
.otherwiseDo(defaultLogic).andLoop()
```

```
 If(someCondition).goTo(stateCode)
.otherwiseDo(defaultLogic).thenGoTo(anotherState)
```

```
Do(someLogic).thenGoTo(someState)
```

Note that if you try to create a looping state without any conditions, it will fire a runtime assertion (which is covered implicitly in unit tests).

The problem is, that function passed to the builder are not function calls, they are function references. Which means that `this` will inevitably get screwed all over. This is why all the methods that can be used by the FSM need to accept parameter of `AiBrain` which is used instead of `this`. Also the second mandatory parameter is `GameContext`.

Methods, that are called from within these top level ones can use `this` normally (they are marked by NON FMS METHODS comment in the code). If you need extra parameters to your methods, or want to pass a parameter directly to the FSM builder, you need to write you own curry function. `and`, `not`, `doNothing` and `timerEnded` are examples of such curries.