### PR TITLE
Move effects when appropriate

### DIFF
--- a/src/events/game-event.ts
+++ b/src/events/game-event.ts
@@ -59,7 +59,10 @@ export function eventSpawnProjectile(options: {
     return e;
 }
 
-export function eventDestroyProjectile(index: number) {
+export function eventDestroyProjectile(
+    index: number,
+    explosionForwardSpeed: Vector,
+) {
     const e: GameEvent = {
         name: "DestroyProjectileEvent",
         process: (context: GameContext): void => {
@@ -72,8 +75,10 @@ export function eventDestroyProjectile(index: number) {
                         position: coords.position,
                         rotation: coords.angle,
                         type: EffectType.ProjectileExplosion,
+                        forward: explosionForwardSpeed,
                     }),
                 );
+                console.log(explosionForwardSpeed);
 
                 context.projectiles.getItem(i).despawn();
                 context.projectiles.popItem(i);
@@ -90,15 +95,6 @@ export function eventDestroyPlayer(index: number) {
         process: (context: GameContext): void => {
             context.players.forEach((p, i) => {
                 if (p.id !== index) return;
-
-                const coords = context.players.getItem(i).getCoords();
-                context.eventQueue.add(
-                    eventCreateEffect({
-                        position: coords.position,
-                        rotation: 0,
-                        type: EffectType.PlayerExplosion,
-                    }),
-                );
 
                 context.players.getItem(i).despawn();
                 context.players.popItem(i);
@@ -128,6 +124,15 @@ export function eventSpawnWreck(options: {
                 forward: options.forward,
                 playerIndex: options.index,
             });
+
+            context.eventQueue.add(
+                eventCreateEffect({
+                    position: options.position,
+                    rotation: 0,
+                    type: EffectType.PlayerExplosion,
+                    forward: options.forward,
+                }),
+            );
         },
     };
     return e;
@@ -174,6 +179,7 @@ export function eventDestroyPowerup(index: number) {
                             .position,
                         rotation: 0,
                         type: EffectType.PowerupPickup,
+                        forward: Vector.zero(),
                     }),
                 );
 
@@ -189,6 +195,7 @@ export function eventCreateEffect(options: {
     position: Vector;
     rotation: number;
     type: EffectType;
+    forward: Vector;
 }) {
     const e: GameEvent = {
         name: "CreateEffectEvent",
@@ -199,6 +206,7 @@ export function eventCreateEffect(options: {
                 position: options.position,
                 rotation: options.rotation,
                 type: options.type,
+                forward: options.forward,
             });
         },
     };

--- a/src/game/collision-mediator.ts
+++ b/src/game/collision-mediator.ts
@@ -110,7 +110,9 @@ export class CollisionMediator {
         context: GameContext,
     ) {
         player.hit(projectile.getDamage());
-        context.eventQueue.add(eventDestroyProjectile(projectile.id));
+        context.eventQueue.add(
+            eventDestroyProjectile(projectile.id, player.getForward()),
+        );
         context.eventEmitter.emit("PlayerWasHit");
     }
 
@@ -127,7 +129,9 @@ export class CollisionMediator {
                         context.settings.OBSTACLE_MASS,
                 ),
         );
-        context.eventQueue.add(eventDestroyProjectile(projectile.id));
+        context.eventQueue.add(
+            eventDestroyProjectile(projectile.id, obstacle.getForward()),
+        );
         context.eventEmitter.emit(
             obstacle.isWreck() ? "WreckWasHit" : "RockWasHit",
         );

--- a/src/game/effect.spec.ts
+++ b/src/game/effect.spec.ts
@@ -33,12 +33,13 @@ describe("Effect", () => {
         effect = gameContext.effects.getItem(0);
     });
 
-    it("#spawn", () => {
-        describe("Spawns correctly", () => {
+    describe("#spawn", () => {
+        it("Spawns correctly", () => {
             effect.spawn({
                 position: new Vector(42, 69),
                 rotation: 45,
                 type: EffectType.PlayerExplosion,
+                forward: new Vector(67, 68),
             });
 
             expect(effect.getCoords().position.x).to.equal(42);
@@ -46,13 +47,16 @@ describe("Effect", () => {
             expect(effect.getCoords().angle).to.equal(45);
             expect(effect.getCoords().frame.x).to.equal(65);
             expect(effect.getCoords().frame.y).to.equal(66);
+            expect(effect.getForward().x).to.equal(67);
+            expect(effect.getForward().y).to.equal(68);
         });
 
-        describe("Repeated spawning with same type resets animation", () => {
+        it("Repeated spawning with same type resets animation", () => {
             effect.spawn({
                 position: new Vector(42, 69),
                 rotation: 45,
                 type: EffectType.PlayerExplosion,
+                forward: Vector.zero(),
             });
 
             // Simulate until frame changes
@@ -65,18 +69,20 @@ describe("Effect", () => {
                 position: new Vector(42, 69),
                 rotation: 45,
                 type: EffectType.PlayerExplosion,
+                forward: Vector.zero(),
             });
             expect(effect.getCoords().frame.x).to.equal(65);
             expect(effect.getCoords().frame.y).to.equal(66);
         });
     });
 
-    it("#update", () => {
-        describe("Creates destroy event when animation ends", () => {
+    describe("#update", () => {
+        it("Creates destroy event when animation ends", () => {
             effect.spawn({
                 position: new Vector(42, 69),
                 rotation: 45,
                 type: EffectType.PlayerExplosion,
+                forward: Vector.zero(),
             });
 
             // Simulate until animation ends
@@ -87,6 +93,19 @@ describe("Effect", () => {
             expect(gameContext.eventQueue.events[0].name).to.equal(
                 "DestroyEffectEvent",
             );
+        });
+
+        it("Moves forward", () => {
+            effect.spawn({
+                position: new Vector(0, 0),
+                rotation: 0,
+                type: EffectType.PlayerExplosion,
+                forward: new Vector(10, 10),
+            });
+
+            effect.update(1, gameContext);
+            expect(effect.getCoords().position.x).to.equal(10);
+            expect(effect.getCoords().position.y).to.equal(10);
         });
     });
 });

--- a/src/game/effect.ts
+++ b/src/game/effect.ts
@@ -20,7 +20,12 @@ export class Effect extends GameObject {
         super();
     }
 
-    spawn(options: { position: Vector; rotation: number; type: EffectType }) {
+    spawn(options: {
+        position: Vector;
+        rotation: number;
+        type: EffectType;
+        forward: Vector;
+    }) {
         this.collider.setPosition(options.position);
         this.rotation = options.rotation;
         this.animationEngine.setState(
@@ -28,9 +33,12 @@ export class Effect extends GameObject {
             false,
             true,
         );
+        this.forward = options.forward;
     }
 
     update(dt: number, context: GameContext): void {
+        this.collider.move(this.forward.getScaled(dt));
+
         if (!this.animationEngine.update(dt)) {
             context.eventQueue.add(eventDestroyEffect(this.id));
         }

--- a/src/game/obstacle.ts
+++ b/src/game/obstacle.ts
@@ -1,10 +1,10 @@
 import { AnimationEngine } from "../utility/animation";
 import { CircleCollider } from "../utility/circle-collider";
+import { Coords } from "../utility/coords";
+import { sanitizeAngle } from "../utility/math";
 import { Vector } from "../utility/vector";
 import { GameContext } from "./game-context";
 import { GameObject } from "./game-object";
-import { Coords } from "../utility/coords";
-import { sanitizeAngle } from "../utility/math";
 
 export class Obstacle extends GameObject {
     protected static RADIUS = 20;
@@ -43,7 +43,6 @@ export class Obstacle extends GameObject {
 
     hit(force: Vector) {
         this.forward.add(force);
-        // TODO: play sound
     }
 
     setForward(fwd: Vector) {

--- a/src/game/projectile.ts
+++ b/src/game/projectile.ts
@@ -1,10 +1,10 @@
-import { CircleCollider } from "../utility/circle-collider";
-import { Vector } from "../utility/vector";
-import { GameObject } from "./game-object";
-import { GameContext } from "./game-context";
 import { eventDestroyProjectile } from "../events/game-event";
 import { AnimationEngine } from "../utility/animation";
+import { CircleCollider } from "../utility/circle-collider";
 import { Coords } from "../utility/coords";
+import { Vector } from "../utility/vector";
+import { GameContext } from "./game-context";
+import { GameObject } from "./game-object";
 
 export class Projectile extends GameObject {
     private damage = 0;
@@ -24,7 +24,9 @@ export class Projectile extends GameObject {
 
         this.selfDestructTimeout -= dt;
         if (this.selfDestructTimeout <= 0)
-            context.eventQueue.add(eventDestroyProjectile(this.id));
+            context.eventQueue.add(
+                eventDestroyProjectile(this.id, Vector.zero()),
+            );
 
         if (context.settings.PROJECTILE_ENABLE_TELEPORT) {
             this.handleLeavingScreenByWrappingAround(context);
@@ -69,7 +71,9 @@ export class Projectile extends GameObject {
             pos.y < 0 ||
             pos.y > context.settings.SCREEN_HEIGHT
         ) {
-            context.eventQueue.add(eventDestroyProjectile(this.id));
+            context.eventQueue.add(
+                eventDestroyProjectile(this.id, Vector.zero()),
+            );
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,8 +279,8 @@ const gameSettings: GameSettings = {
     PRNG_SEED: 0,
     FIXED_FRAME_TIME: 1 / FPS,
     // Spawn settings
-    PLAYER_COUNT: 3,
-    NPC_COUNT: 1,
+    PLAYER_COUNT: 4,
+    NPC_COUNT: 4,
     ROCK_COUNT: 4,
     PLAYER_INITIAL_HEALTH: 3,
     PLAYER_INITIAL_ENERGY: 2,


### PR DESCRIPTION
When effect (player/projectile explosion) is happening in context with a moving object, move along with the object at same speed.