### PR TITLE
Feature: Show profiler in game

### DIFF
--- a/workspaces/backend/src/events/client-events.ts
+++ b/workspaces/backend/src/events/client-events.ts
@@ -9,6 +9,6 @@ export interface ClientEvents {
     // This is automatic for the player who created the lobby
     lobbyEntered: (gameCode: string, clientState: ClientState) => void;
     lobbyLeft: () => void;
-    gameInputGathered: (inputs: boolean[]) => void;
+    gameInputGathered: (inputs: boolean[], callback: () => void) => void;
     gameListRequested: () => void;
 }

--- a/workspaces/backend/src/main.ts
+++ b/workspaces/backend/src/main.ts
@@ -153,7 +153,9 @@ io.on("connection", (socket) => {
         }
     });
 
-    socket.on("gameInputGathered", (inputs: boolean[]) => {
+    socket.on("gameInputGathered", (inputs: boolean[], ack: () => void) => {
+        ack(); // Socket.io acknowledgement
+
         try {
             const game = getGameByClient(socket.id);
             game.receiveClientInput(socket.id, inputs);
@@ -187,33 +189,6 @@ io.on("connection", (socket) => {
                 numConnected: netStateMgr.state.clients.length,
             });
         });
-
-        infos.push({ id: "dummy1", numConnected: 4 });
-        infos.push({ id: "dummy2", numConnected: 3 });
-        infos.push({ id: "dummy3", numConnected: 2 });
-        infos.push({ id: "dummy4", numConnected: 2 });
-        infos.push({ id: "dummy5", numConnected: 2 });
-        infos.push({ id: "dummy6", numConnected: 1 });
-        infos.push({ id: "dummy7", numConnected: 1 });
-        infos.push({ id: "dummy8", numConnected: 1 });
-        infos.push({ id: "dummy9", numConnected: 1 });
-        infos.push({ id: "dummy10", numConnected: 1 });
-        infos.push({ id: "dummy11", numConnected: 1 });
-        infos.push({ id: "dummy12", numConnected: 1 });
-        infos.push({ id: "dummy13", numConnected: 1 });
-        infos.push({ id: "dummy14", numConnected: 1 });
-        infos.push({ id: "dummy15", numConnected: 1 });
-        infos.push({ id: "dummy16", numConnected: 1 });
-        infos.push({ id: "dummy17", numConnected: 1 });
-        infos.push({ id: "dummy18", numConnected: 1 });
-        infos.push({ id: "dummy19", numConnected: 1 });
-        infos.push({ id: "dummy20", numConnected: 1 });
-        infos.push({ id: "dummy21", numConnected: 1 });
-        infos.push({ id: "dummy22", numConnected: 1 });
-        infos.push({ id: "dummy23", numConnected: 1 });
-        infos.push({ id: "dummy24", numConnected: 1 });
-        infos.push({ id: "dummy25", numConnected: 1 });
-        infos.push({ id: "dummy26", numConnected: 1 });
 
         socket.emit("gameListCollected", infos);
     });

--- a/workspaces/frontend/src/app/app-runner.ts
+++ b/workspaces/frontend/src/app/app-runner.ts
@@ -1,5 +1,10 @@
 import { Releasable } from "./releasable";
 
+export interface AppStats {
+    simulationTime: number;
+    latency: number;
+}
+
 /**
  * Generic class that provides frame time contants
  * computed from FPS and single point of entry for
@@ -8,6 +13,12 @@ import { Releasable } from "./releasable";
 export abstract class AppRunner extends Releasable {
     protected frameTimeSec = 0;
     protected frameTimeMsec = 0;
+    protected reportStats: (stats: AppStats) => void;
+
+    constructor() {
+        super();
+        this.reportStats = () => { /* empty handler */ };
+    }
 
     run(fps: number) {
         this.frameTimeSec = 1 / fps;
@@ -16,4 +27,8 @@ export abstract class AppRunner extends Releasable {
     }
 
     protected abstract runInternal(): void;
+
+    public installStatsReporter(reportStats: (stats: AppStats) => void) {
+        this.reportStats = reportStats;
+    }
 }

--- a/workspaces/frontend/src/app/local-app-runner.ts
+++ b/workspaces/frontend/src/app/local-app-runner.ts
@@ -10,7 +10,13 @@ export class LocalAppRunner extends AppRunner {
 
     protected override runInternal(): void {
         this.intervalHandle = setInterval(() => {
+            const start = Date.now();
             this.app.updateLogic(this.frameTimeSec);
+
+            this.reportStats({
+                simulationTime: Date.now() - start,
+                latency: 0,
+            })
         }, this.frameTimeMsec);
     }
 

--- a/workspaces/frontend/src/ui/components/GameStatsDisplay.css
+++ b/workspaces/frontend/src/ui/components/GameStatsDisplay.css
@@ -1,0 +1,12 @@
+#GameStatsDisplay {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    width: 200px;
+    height: 100px;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+.hidden_elem {
+    display: none;
+}

--- a/workspaces/frontend/src/ui/components/GameStatsDisplay.tsx
+++ b/workspaces/frontend/src/ui/components/GameStatsDisplay.tsx
@@ -1,0 +1,20 @@
+import { Accessor } from "solid-js";
+import "./GameStatsDisplay.css";
+
+interface GameStatsProps {
+    hidden: Accessor<boolean>;
+    simulationTime: Accessor<number>;
+    latency: Accessor<number>;
+}
+
+export function GameStatsDisplay(props: GameStatsProps)
+{
+    return (
+        <div id="GameStatsDisplay" classList={{
+            hidden_elem: props.hidden(),
+        }}>
+            <div>Simul time: { props.simulationTime() } ms</div>
+            <div>Latency: { props.latency() } ms</div>
+        </div>
+    )
+}

--- a/workspaces/frontend/src/ui/game/Game.tsx
+++ b/workspaces/frontend/src/ui/game/Game.tsx
@@ -1,6 +1,6 @@
-import { Accessor, onCleanup, onMount, Setter } from "solid-js";
+import { Accessor, createSignal, onCleanup, onMount, Setter } from "solid-js";
 import { JSX } from "solid-js/jsx-runtime";
-import { AppRunner } from "../../app/app-runner";
+import { AppRunner, AppStats } from "../../app/app-runner";
 import { PlayerSettings } from "../../game/player-settings";
 import {
     CreateGameEventEmitter,
@@ -11,8 +11,14 @@ import {
 import { TinywarsSocket } from "../../networking/types";
 import { AppController } from "../appstate/AppController";
 import { AppState } from "../appstate/AppState";
+import { Checkbox } from "../components/Checkbox";
+import { GameStatsDisplay } from "../components/GameStatsDisplay";
 import { logMount, logUnmount } from "../UiLogger";
 import "./Game.css";
+
+const [ profilerHidden, setProfilerHidden ] = createSignal(true);
+const [ simulationTime, setSimulationTime ] = createSignal(0);
+const [ latency, setLatency ] = createSignal(0);
 
 export class GameState extends AppState {
     private appRunner: AppRunner | undefined;
@@ -74,6 +80,10 @@ export class GameState extends AppState {
         // Must initialize apprunner after component is rendered
         // because it fetches reference to canvas element
         this.appRunner = this.init();
+        this.appRunner.installStatsReporter((stats: AppStats) => {
+            setSimulationTime(stats.simulationTime);
+            setLatency(stats.latency)
+        });
         this.appRunner?.run(this.FPS);
     }
 
@@ -107,7 +117,7 @@ function GameStateView(props: {
     });
 
     return (
-        <table id="GameView">
+        <><table id="GameView">
             <tbody>
                 <tr>
                     <td id="RenderCanvasParent">
@@ -130,8 +140,7 @@ function GameStateView(props: {
                                                     event.currentTarget.value,
                                                 ),
                                             );
-                                        }}
-                                    />
+                                        } } />
                                 </div>
                                 <br />
                                 <div class="hbox space-between">
@@ -147,8 +156,18 @@ function GameStateView(props: {
                                                     event.currentTarget.value,
                                                 ),
                                             );
-                                        }}
-                                    />
+                                        } } />
+                                </div>
+                                <br />
+                                <div class="hbox space-between">
+                                    <label for="ProfilerToggleInput">Display profiler</label>
+                                    <Checkbox
+                                        id="ProfilerToggleInput"
+                                        name="ProfilerToggleInput"
+                                        checked={!profilerHidden()}
+                                        onToggle={() => {
+                                            setProfilerHidden(!profilerHidden());
+                                        }} />
                                 </div>
                                 <br />
                                 <button
@@ -161,6 +180,9 @@ function GameStateView(props: {
                     </td>
                 </tr>
             </tbody>
-        </table>
+        </table><GameStatsDisplay
+            hidden={profilerHidden}
+            simulationTime={simulationTime}
+            latency={latency} /></>
     );
 }


### PR DESCRIPTION
Added a new checkbox to in-game sidebar that allows you to turn on a rudimentary profiler.
This profiler logs how many ms it takes to compute game logic and also how many ms does take round trip of each socket message.