### PR TITLE
Feature: Invert steer on reverse works in netgame

### DIFF
--- a/workspaces/frontend/src/ui/components/PlayerSettingsCard.tsx
+++ b/workspaces/frontend/src/ui/components/PlayerSettingsCard.tsx
@@ -38,26 +38,30 @@ export function PlayerSettingsCard(props: PlayerSettingsCardProps) {
                 />
             </div>
 
-            <div>
-                <label for={`InvertSteer_${props.index}`}>
+            <Switch>
+                <Match when={props.enabled}>
+                    <div>
+                        <label for={`InvertSteer_${props.index}`}>
                     Invert reverse steering:
-                </label>
-                <Checkbox
-                    id={`InvertSteer_${props.index}`}
-                    name="InvertSteer"
-                    checked={props.settings.invertSteeringOnReverse}
-                    onToggle={() => {
-                        props.settings.invertSteeringOnReverse =
+                        </label>
+                        <Checkbox
+                            id={`InvertSteer_${props.index}`}
+                            name="InvertSteer"
+                            checked={props.settings.invertSteeringOnReverse}
+                            onToggle={() => {
+                                props.settings.invertSteeringOnReverse =
                             !props.settings.invertSteeringOnReverse;
-                        props.setSettings(props.settings);
-                    }}
-                    disabled={!props.enabled}
-                />
-            </div>
-
-            <div>
-                <Switch>
-                    <Match when={!props.netgame}>
+                                props.setSettings(props.settings);
+                            }}
+                            disabled={!props.enabled}
+                        />
+                    </div>
+                </Match>
+            </Switch>
+            
+            <Switch>
+                <Match when={!props.netgame}>
+                    <div>
                         <label for={`ComputerControl_${props.index}`}>
                             AI controlled:
                         </label>
@@ -72,9 +76,9 @@ export function PlayerSettingsCard(props: PlayerSettingsCardProps) {
                             }}
                             disabled={!props.enabled}
                         />
-                    </Match>
-                </Switch>
-            </div>
+                    </div>
+                </Match>
+            </Switch>
         </div>
     );
 }

--- a/workspaces/frontend/src/ui/lobby/NetworkGameLobby.tsx
+++ b/workspaces/frontend/src/ui/lobby/NetworkGameLobby.tsx
@@ -116,7 +116,8 @@ export class NetworkGameLobbyState extends AppState {
     private updateAllPlayers(gameState: NetGameState) {
         const playerData: PlayerSettings[] = [];
         gameState.clients.forEach((c, i) => {
-            if (c.id === this.socket.id) {
+            const isMyState = c.id === this.socket.id;
+            if (isMyState) {
                 this.setMyIndex(i);
 
                 if (c.disconnected) {
@@ -124,10 +125,14 @@ export class NetworkGameLobbyState extends AppState {
                 }
             }
 
+            const mySettingsAreInitialized = this.playerSettings().length > this.myIndex();
+            const invertSteeringOnReverse = isMyState && mySettingsAreInitialized
+                ? this.playerSettings()[this.myIndex()].invertSteeringOnReverse
+                : false;
+
             playerData.push({
                 name: c.name,
-                // not implemented in netgame
-                invertSteeringOnReverse: false,
+                invertSteeringOnReverse: invertSteeringOnReverse,
                 // following two are completely ignored in netgame for anybody else than me
                 isComputerControlled: false,
                 controls: PLAYER1_DEFAULT_CONTROLS,


### PR DESCRIPTION
It was just a matter of propagating that setting to game. Since we have abstracted controllers, it doesn't have to be propagated to remote peers.