### PR TITLE
Fixed spawn positions being always the same on the start of the round

### DIFF
--- a/workspaces/frontend/src/app/app.ts
+++ b/workspaces/frontend/src/app/app.ts
@@ -140,6 +140,10 @@ export class App extends Releasable {
             );
         });
 
+        const seed =
+            this.settings.PRNG_SEED == 0 ? Date.now() : this.settings.PRNG_SEED;
+        PRNG.setSeed(seed);
+
         this.reset();
         this.eventEmitter.emit("GameStarted");
     }
@@ -214,11 +218,6 @@ export class App extends Releasable {
     }
 
     private reset() {
-        const seed =
-            this.settings.PRNG_SEED == 0 ? Date.now() : this.settings.PRNG_SEED;
-        PRNG.setSeed(seed);
-        console.log(`SEED: ${seed}`);
-
         this.endgame = false;
         this.timeTillRestart = 0;
 


### PR DESCRIPTION
The seed has been reset to initial value on the start of every round. Logic moved to be done one time only.